### PR TITLE
patch the API to support proper post handing

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -29,11 +29,19 @@ var FORMDATA_PATHS = [
   'account/update_profile_background_image',
 ];
 
+// if the path starts with anything on this list, then the 
+// payload will be sent as a json payload.
 var JSONPAYLOAD_PATHS = [
-  'media/metadata/create',
-  'direct_messages/events/new',
-  'direct_messages/welcome_messages/new',
-  'direct_messages/welcome_messages/rules/new',
+    'media/metadata/create',
+    'direct_messages/events/new',
+    'direct_messages/welcome_messages/new',
+    'direct_messages/welcome_messages/rules/new',
+    'insights/engagement',
+    'insights/engagement/totals',
+    'insights/engagement/28hr',
+    'insights/engagement/historical',
+    'search/30day',
+    'search/fullarchive'
 ];
 
 //
@@ -97,9 +105,10 @@ Twitter.prototype.request = function (method, path, params, callback) {
       }
 
       var twitOptions = (params && params.twit_options) || {};
-
+      
       process.nextTick(function () {
         // ensure all HTTP i/o occurs after the user has a chance to bind their event handlers
+
         self._doRestApiRequest(reqOpts, twitOptions, method, function (err, parsedBody, resp) {
           self._updateClockOffsetFromResponse(resp);
           var peerCertificate = resp && resp.socket && resp.socket.getPeerCertificate();
@@ -195,8 +204,18 @@ Twitter.prototype._buildReqOpts = function (method, path, params, isStreaming, c
   }
   // clone `params` object so we can modify it without modifying the user's reference
   var paramsClone = JSON.parse(JSON.stringify(params))
-  // convert any arrays in `paramsClone` to comma-seperated strings
-  var finalParams = this.normalizeParams(paramsClone)
+
+  // jna: only permit this to happen if we are doing a GET request. There is no
+  // reason to do this in a POST. it breaks things like the enterprise API.
+
+  // convert any arrays in `paramsClone` to comma-separated strings
+  var finalParams;
+  if (method == 'GET') {
+    finalParams = this.normalizeParams(paramsClone)
+  } else { 
+    finalParams = paramsClone;
+  }
+
   delete finalParams.twit_options
 
   // the options object passed to `request` used to perform the HTTP request
@@ -219,7 +238,31 @@ Twitter.prototype._buildReqOpts = function (method, path, params, isStreaming, c
   
   // finalize the `path` value by building it using user-supplied params
   // when json parameters should not be in the payload
-  if (JSONPAYLOAD_PATHS.indexOf(path) === -1) {
+
+  // jna: The public version of this library does not deal with 
+  // full paths. The matcher breaks substantially when the path 
+  // starts with http(s)://. Fix this by extracting the path
+  // component and testing that instead of the full "path", which is
+  // actually a "url".
+  let testPath;
+
+  try { 
+    // if we can parse the string as a url, we must extract the path
+    const parsedUrl = new URL(path);
+    testPath = parsedUrl.pathname;
+    if (testPath[0] == '/') { 
+      testPath = testPath.substring(1, testPath.length);
+    }
+  } catch(e) { 
+    // we only expect TypeError here, which reads as "Invalid URL."
+    if (! e instanceof TypeError) { 
+      throw e; // unexpected, so throw it again. Not our problem.
+    }
+    // just pass it through untouched.
+    testPath = path;
+  }
+
+  if (JSONPAYLOAD_PATHS.indexOf(testPath) === -1) {
     try {
       path = helpers.moveParamsIntoPath(finalParams, path)
     } catch (e) {
@@ -230,11 +273,20 @@ Twitter.prototype._buildReqOpts = function (method, path, params, isStreaming, c
 
   if (path.match(/^https?:\/\//i)) {
     // This is a full url request
-    reqOpts.url = path
+    reqOpts.url = path;
+
+    // if the endpoint requires JSON, set up options correctly.
+    if (JSONPAYLOAD_PATHS.indexOf(testPath) !== -1) {
+      reqOpts.headers['Content-type'] = 'application/json';
+      reqOpts.json = true;
+      reqOpts.body = finalParams;
+
+      // avoid appending query string for body params
+      finalParams = {};
+    }
   } else
   if (isStreaming) {
     // This is a Streaming API request.
-
     var stream_endpoint_map = {
       user: endpoints.USER_STREAM,
       site: endpoints.SITE_STREAM
@@ -257,7 +309,7 @@ Twitter.prototype._buildReqOpts = function (method, path, params, isStreaming, c
        // set finalParams to empty object so we don't append a query string
       // of the params
       finalParams = {};
-    } else if (JSONPAYLOAD_PATHS.indexOf(path) !== -1) {
+    } else if (JSONPAYLOAD_PATHS.indexOf(testPath) !== -1) {
       reqOpts.headers['Content-type'] = 'application/json';
       reqOpts.json = true;
       reqOpts.body = finalParams;


### PR DESCRIPTION
Adds support for the enterprise API and ensures JSON posting to them.

Stops trying to convert arrays into comma separated lists if we're doing a POST

Fix the matcher. It doesn't work right when a fully qualified URL is submitted as a path.